### PR TITLE
bugfix

### DIFF
--- a/src/base-dialog.js
+++ b/src/base-dialog.js
@@ -3,7 +3,9 @@ define(function(require, exports, module) {
     var $ = require('$'),
         Overlay = require('overlay'),
         mask = require('mask'),
-        Events = require('events');
+        Events = require('events'),
+        
+        TRIGGER_EVENT_NS = '.trigger-events-';
 
 
     // BaseDialog
@@ -73,7 +75,7 @@ define(function(require, exports, module) {
         },
 
         destroy: function() {
-            this.get('trigger').off(this.get('triggerType'));
+            this.get('trigger').off(this.get('triggerType') + TRIGGER_EVENT_NS + this.cid);
             return BaseDialog.superclass.destroy.call(this);            
         },
 
@@ -91,7 +93,7 @@ define(function(require, exports, module) {
         // 绑定触发对话框出现的事件
         _setupTrigger: function() {
             var that = this;
-            this.get('trigger').on(this.get('triggerType'), function(e) {
+            this.get('trigger').on(this.get('triggerType') + TRIGGER_EVENT_NS + this.cid, function(e) {
                 e.preventDefault();
                 that.activeTrigger = this; 
                 that.show();


### PR DESCRIPTION
修复了2个问题
1. https://github.com/aralejs/dialog/issues/5
2. 给trigger的事件绑定增加了命名空间的概念，防止在Dialog实例destroy时，将非组件绑定在trigger上的事件**误注销**
