### PR TITLE
修复 top 为负数的场景

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -77,9 +77,9 @@ define(function(require, exports, module) {
                     baseXY: ['50%', '42%']
                 },
                 getter: function(val) {
-                    // 高度超过一屏的情况
+                    // 高度超过窗口的 42/50 浮层头部顶住窗口
                     // https://github.com/aralejs/dialog/issues/41
-                    if (this.element.height() > $(window).height()) {
+                    if (this.element.height() > $(window).height() * 0.84) {
                         return {
                             selfXY: ['50%', '0'],
                             baseXY: ['50%', '0']


### PR DESCRIPTION
如果屏幕宽度为 200，浮层宽度为 170，那还是会使用 42% 居中定位，但这种场景定位后浮层的 top 会为负数 (200 \* 42% < 170 *50%)
