### PR TITLE
如果当前 hide 的 dialog 不在最顶层，也需要从 mask._dialogs 中将它移除。

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -264,18 +264,33 @@ var Dialog = Overlay.extend({
       return;
     }
 
-    if (mask._dialogs) {
-      // 当且仅当最后一个 dialog 是当前 dialog 时，才移除
-      // 因为 hide 与 destroy 都会调用 _hideMask，此举用于避免错误移除
-      if (mask._dialogs[mask._dialogs.length - 1] === this) {
-        mask._dialogs.pop();
+    var dialogs = mask._dialogs,
+      // 当前是否最后一个 dialog，即当前是否位于顶层
+      currentIsLast = false;
+
+    if (dialogs) {
+      // check last
+      if (dialogs[dialogs.length - 1] === this) {
+        currentIsLast = true;
+        dialogs.pop();
+      }
+      // check others
+      else {
+        for (var i = 0; i < dialogs.length - 1; i++) {
+          if (dialogs[i] === this) {
+            dialogs.splice(i, 1);
+          }
+        }
       }
     }
 
-    if (mask._dialogs && mask._dialogs.length > 0) {
-      var last = mask._dialogs[mask._dialogs.length - 1];
-      mask.set('zIndex', last.get('zIndex'));
-      mask.element.insertBefore(last.element);
+    if (dialogs && dialogs.length > 0) {
+      // 如果当前是顶层，则寻找新的顶层，否则不做处理
+      if (currentIsLast) {
+        var last = dialogs[dialogs.length - 1];
+        mask.set('zIndex', last.get('zIndex'));
+        mask.element.insertBefore(last.element);
+      }
     } else {
       mask.hide();
     }

--- a/tests/dialog-spec.js
+++ b/tests/dialog-spec.js
@@ -463,6 +463,40 @@ describe('dialog', function () {
       expect(mask.get('visible')).to.be(false);
     });
 
+    it('should remove from mask._dialogs when dialog(NOT last one) is hide', function() {
+      example = new Dialog({
+        content: 'foo'
+      });
+      example.show();
+
+      expect(mask._dialogs.length).to.be(1);
+      expect(mask.get('visible')).to.be(true);
+      expect(mask.element.next()[0]).to.be(example.element[0]);
+
+      var example2 = new Dialog({
+        content: 'bar'
+      });
+
+      example2.show();
+      expect(mask._dialogs.length).to.be(2);
+      expect(mask.get('visible')).to.be(true);
+      expect(mask.element.next()[0]).to.be(example2.element[0]);
+
+      // 通过脚本隐藏非顶层的 dialog
+      example.hide();
+      // 此时应移除存在 mask._dialogs 中对应的 dialog
+      expect(mask._dialogs.length).to.be(1);
+      // mask 保持原样不作处理
+      expect(mask.get('visible')).to.be(true);
+      expect(mask.element.next()[0]).to.be(example2.element[0]);
+
+      example2.hide();
+      expect(mask._dialogs.length).to.be(0);
+      expect(mask.get('visible')).to.be(false);
+
+      example2.destroy();
+    });
+
     it('set hasMask works', function () {
       example = new Dialog({
         content: 'xxx'


### PR DESCRIPTION
此需求在复杂业务中可能出现，如：
http://aralejs.org/dialog/examples/two-dialog.html 页面中，
第二个 dialog 打开后，
通过脚本调用第一个 dialog 的 hide 方法，
原来的逻辑不会从 mask._dialogs 中移除第一个 dialog。
这将导致问题：接着关闭第二个 dialog，此时界面上 dialog 数为 0，但 mask 依然显示。

另，顺便将 mask._dialogs 存到局部变量，以利压缩率。