### PR TITLE
jquery1.8以上版本去掉了$(element).data('events'),所以测试用例 should have a worked co...

### DIFF
--- a/tests/dialog-spec.js
+++ b/tests/dialog-spec.js
@@ -367,11 +367,11 @@ describe('dialog', function () {
         content: './height200px.html'
       });
       example.on('complete:show', function () {
-        expect(example.$('iframe').data('events')).to.be(undefined);
+        expect($._data(example.$('iframe')[0], "events")).to.be(undefined);
         done();
       });
       example.show();
-      expect(example.$('iframe').data('events').load).to.be.a('object');
+      expect($._data(example.$('iframe')[0], "events").load).to.be.a('object');
     });
 
   });


### PR DESCRIPTION
...mplete:show event 会报错，  修改为$._data(element,"events") jquery1.72及以上都ok