### PR TITLE
add cross domain iframe support 

### DIFF
--- a/examples/cross-domain-iframe.md
+++ b/examples/cross-domain-iframe.md
@@ -6,10 +6,10 @@
 
 <button id="trigger-btn">跨域Iframe</button>
 ````javascript
-seajs.use(['dialog','jquery'], function(Dialog, $) {
-  new Dialog({
-    trigger: '#trigger-btn',
-    content: 'http://spmjs.io/docs/arale-dialog-iframe-helper/examples/index.html'
-  });
+var Dialog = require('dialog');
+var $ = require('jquery');
+new Dialog({
+  trigger: '#trigger-btn',
+  content: 'http://spmjs.io/docs/arale-dialog-iframe-helper/examples/index.html'
 });
 ````

--- a/examples/cross-domain-iframe.md
+++ b/examples/cross-domain-iframe.md
@@ -1,0 +1,13 @@
+# 跨域iframe
+
+---------
+
+<button id="trigger-btn">跨域Iframe</button>
+````javascript
+seajs.use(['dialog','jquery'], function(Dialog, $) {
+  new Dialog({
+    trigger: '#trigger-btn',
+    content: 'http://shaoshuai.me/test.html'
+  });
+});
+````

--- a/examples/cross-domain-iframe.md
+++ b/examples/cross-domain-iframe.md
@@ -2,12 +2,14 @@
 
 ---------
 
+嵌入跨域iframe时，请在iframe页面中使用[arale-dialog-iframe-helper](http://spmjs.io/docs/arale-dialog-iframe-helper/)组件，以便于和父页面进行通信。
+
 <button id="trigger-btn">跨域Iframe</button>
 ````javascript
 seajs.use(['dialog','jquery'], function(Dialog, $) {
   new Dialog({
     trigger: '#trigger-btn',
-    content: 'http://shaoshuai.me/test.html'
+    content: 'http://spmjs.io/docs/arale-dialog-iframe-helper/examples/index.html'
   });
 });
 ````

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
       "arale-events": "1.2.0",
       "arale-templatable": "0.10.0",
       "handlebars-runtime": "1.3.0",
-      "arale-messenger": "2.1.0",
-      "json": "0.0.2"
+      "arale-messenger": "2.1.0"
     },
     "devDependencies": {
       "expect.js": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
       "arale-overlay": "1.2.0",
       "arale-events": "1.2.0",
       "arale-templatable": "0.10.0",
-      "handlebars-runtime": "1.3.0"
+      "handlebars-runtime": "1.3.0",
+      "arale-messenger": "2.1.0",
+      "json": "0.0.2"
     },
     "devDependencies": {
       "expect.js": "0.3.1",

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -312,12 +312,12 @@ var Dialog = Overlay.extend({
       this._createIframe();
     }
 
-    this._isCrossDomainIframe = isCrossDomainIframe(this.iframe);
     // 开始请求 iframe
     this.iframe.attr({
       src: this._fixUrl(),
       name: 'dialog-iframe' + new Date().getTime()
     });
+
     // 因为在 IE 下 onload 无法触发
     // http://my.oschina.net/liangrockman/blog/24015
     // 所以使用 jquery 的 one 函数来代替 onload
@@ -327,6 +327,9 @@ var Dialog = Overlay.extend({
       if (!that.get('visible')) {
         return;
       }
+
+      // 是否跨域的判断需要放入iframe load之后
+      that._isCrossDomainIframe = isCrossDomainIframe(that.iframe);
 
       if (!that._isCrossDomainIframe) {
         // 绑定自动处理高度的事件

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -3,8 +3,7 @@ var $ = require('jquery'),
     mask = Overlay.Mask,
     Events = require('arale-events'),
     Templatable = require('arale-templatable'),
-    Messenger = require('arale-messenger'),
-    JSON = require('json');
+    Messenger = require('arale-messenger');
 
 // Dialog
 // ---
@@ -137,8 +136,8 @@ var Dialog = Overlay.extend({
   hide: function () {
     // 把 iframe 状态复原
     if (this._type === 'iframe' && this.iframe) {
-      // 如果是跨域iframe，会抛出异常
-      if (!isCrossDomainIframe(this.iframe)) {
+      // 如果是跨域iframe，会抛出异常，所以需要加一层判断
+      if (!this._isCrossDomainIframe) {
         this.iframe.attr({
           src: 'javascript:\'\';'
         });
@@ -312,6 +311,8 @@ var Dialog = Overlay.extend({
     if (!this.iframe) {
       this._createIframe();
     }
+
+    this._isCrossDomainIframe = isCrossDomainIframe(this.iframe);
     // 开始请求 iframe
     this.iframe.attr({
       src: this._fixUrl(),
@@ -327,7 +328,7 @@ var Dialog = Overlay.extend({
         return;
       }
 
-      if (!isCrossDomainIframe(that.iframe)) {
+      if (!that._isCrossDomainIframe) {
         // 绑定自动处理高度的事件
         if (that.get('autoFit')) {
           clearInterval(that._interval);


### PR DESCRIPTION
使用`arale-messenger`进行跨域支持。

计划在写一个简单封装，便于iframe内部实现，向parent页面发布同步高度和关闭事件。