### PR TITLE
Fix "onCancel not a function error" when onCancel is omitted.

### DIFF
--- a/src/confirmbox.js
+++ b/src/confirmbox.js
@@ -82,6 +82,7 @@ ConfirmBox.confirm = function (message, title, onConfirm, onCancel, options) {
   // support confirm(message, title, onConfirm, options)
   if (typeof onCancel === 'object' && !options) {
     options = onCancel;
+    onCancel = null;
   }
 
   var defaults = {


### PR DESCRIPTION
onCancel should be marked as "false" value when it's not a function