### PR TITLE
fixed ie8 "x.default" not work

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,8 @@
   ],
   "plugins": [
     "add-module-exports",
-    "transform-class-properties"
+    "transform-class-properties",
+    "transform-es3-member-expression-literals",
+    "transform-es3-property-literals"
   ]
 }

--- a/lib/confirmbox.js
+++ b/lib/confirmbox.js
@@ -14,14 +14,14 @@ var _spmHandlebars = require('spm-handlebars');
 
 var _spmHandlebars2 = _interopRequireDefault(_spmHandlebars);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var template = _spmHandlebars2.default['default'].compile('{{#if title}}\n                <div class="{{classPrefix}}-title" data-role="title">{{{title}}}</div>\n                {{/if}}\n                <div class="{{classPrefix}}-container">\n                    <div class="{{classPrefix}}-message" data-role="message">{{{message}}}</div>\n                    {{#if hasFoot}}\n                    <div class="{{classPrefix}}-operation" data-role="foot">\n                        {{#if confirmTpl}}\n                        <div class="{{classPrefix}}-confirm" data-role="confirm">\n                            {{{confirmTpl}}}\n                        </div>\n                        {{/if}}\n                        {{#if cancelTpl}}\n                        <div class="{{classPrefix}}-cancel" data-role="cancel">\n                            {{{cancelTpl}}}\n                        </div>\n                        {{/if}}\n                    </div>\n                    {{/if}}\n                </div>');
+var template = _spmHandlebars2['default']['default'].compile('{{#if title}}\n                <div class="{{classPrefix}}-title" data-role="title">{{{title}}}</div>\n                {{/if}}\n                <div class="{{classPrefix}}-container">\n                    <div class="{{classPrefix}}-message" data-role="message">{{{message}}}</div>\n                    {{#if hasFoot}}\n                    <div class="{{classPrefix}}-operation" data-role="foot">\n                        {{#if confirmTpl}}\n                        <div class="{{classPrefix}}-confirm" data-role="confirm">\n                            {{{confirmTpl}}}\n                        </div>\n                        {{/if}}\n                        {{#if cancelTpl}}\n                        <div class="{{classPrefix}}-cancel" data-role="cancel">\n                            {{{cancelTpl}}}\n                        </div>\n                        {{/if}}\n                    </div>\n                    {{/if}}\n                </div>');
 
 // ConfirmBox
 // -------
 // ConfirmBox 是一个有基础模板和样式的对话框组件。
-var ConfirmBox = _dialog2.default.extend({
+var ConfirmBox = _dialog2['default'].extend({
   attrs: {
     title: '默认标题',
 
@@ -86,7 +86,7 @@ ConfirmBox.alert = function (message, callback, options) {
       this.hide();
     }
   };
-  new ConfirmBox(_jquery2.default.extend(null, defaults, options)).show().after('hide', function () {
+  new ConfirmBox(_jquery2['default'].extend(null, defaults, options)).show().after('hide', function () {
     this.destroy();
   });
 };
@@ -111,7 +111,7 @@ ConfirmBox.confirm = function (message, title, _onConfirm, _onCancel, options) {
       this.hide();
     }
   };
-  new ConfirmBox(_jquery2.default.extend(null, defaults, options)).show().after('hide', function () {
+  new ConfirmBox(_jquery2['default'].extend(null, defaults, options)).show().after('hide', function () {
     this.destroy();
   });
 };
@@ -123,7 +123,7 @@ ConfirmBox.show = function (message, callback, options) {
     confirmTpl: false,
     cancelTpl: false
   };
-  new ConfirmBox(_jquery2.default.extend(null, defaults, options)).show().before('hide', function () {
+  new ConfirmBox(_jquery2['default'].extend(null, defaults, options)).show().before('hide', function () {
     callback && callback();
   }).after('hide', function () {
     this.destroy();

--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -22,18 +22,16 @@ var _araleMessenger = require('arale-messenger');
 
 var _araleMessenger2 = _interopRequireDefault(_araleMessenger);
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var mask = _araleOverlay2.default.Mask;
-
-console.log(_araleOverlay2.default, _araleTemplatable2.default);
+var mask = _araleOverlay2['default'].Mask;
 // Dialog
 // ---
 // Dialog 是通用对话框组件，提供显隐关闭、遮罩层、内嵌iframe、内容区域自定义功能。
 // 是所有对话框类型组件的基类。
-var Dialog = _araleOverlay2.default.extend({
+var Dialog = _araleOverlay2['default'].extend({
 
-  Implements: _araleTemplatable2.default,
+  Implements: _araleTemplatable2['default'],
 
   attrs: {
     // 模板
@@ -43,7 +41,7 @@ var Dialog = _araleOverlay2.default.extend({
     trigger: {
       value: null,
       getter: function getter(val) {
-        return (0, _jquery2.default)(val);
+        return (0, _jquery2['default'])(val);
       }
     },
 
@@ -99,7 +97,7 @@ var Dialog = _araleOverlay2.default.extend({
       getter: function getter(val) {
         // 高度超过窗口的 42/50 浮层头部顶住窗口
         // https://github.com/aralejs/dialog/issues/41
-        if (this.element.height() > (0, _jquery2.default)(window).height() * 0.84) {
+        if (this.element.height() > (0, _jquery2['default'])(window).height() * 0.84) {
           return {
             selfXY: ['50%', '0'],
             baseXY: ['50%', '0']
@@ -203,7 +201,7 @@ var Dialog = _araleOverlay2.default.extend({
       var value;
       // 有些情况会报错
       try {
-        value = (0, _jquery2.default)(val);
+        value = (0, _jquery2['default'])(val);
       } catch (e) {
         value = [];
       }
@@ -246,7 +244,7 @@ var Dialog = _araleOverlay2.default.extend({
     this.delegateEvents(this.get('trigger'), 'click', function (e) {
       e.preventDefault();
       // 标识当前点击的元素
-      this.activeTrigger = (0, _jquery2.default)(e.currentTarget);
+      this.activeTrigger = (0, _jquery2['default'])(e.currentTarget);
       this.show();
     });
   },
@@ -329,7 +327,7 @@ var Dialog = _araleOverlay2.default.extend({
 
   // 绑定键盘事件，ESC关闭窗口
   _setupKeyEvents: function _setupKeyEvents() {
-    this.delegateEvents((0, _jquery2.default)(document), 'keyup.esc', function (e) {
+    this.delegateEvents((0, _jquery2['default'])(document), 'keyup.esc', function (e) {
       if (e.keyCode === 27) {
         this.get('visible') && this.hide();
       }
@@ -388,7 +386,7 @@ var Dialog = _araleOverlay2.default.extend({
   _createIframe: function _createIframe() {
     var that = this;
 
-    this.iframe = (0, _jquery2.default)('<iframe>', {
+    this.iframe = (0, _jquery2['default'])('<iframe>', {
       src: 'javascript:\'\';',
       scrolling: 'no',
       frameborder: 'no',
@@ -404,13 +402,13 @@ var Dialog = _araleOverlay2.default.extend({
 
     // 给 iframe 绑一个 close 事件
     // iframe 内部可通过 window.frameElement.trigger('close') 关闭
-    _araleEvents2.default.mixTo(this.iframe[0]);
+    _araleEvents2['default'].mixTo(this.iframe[0]);
     this.iframe[0].on('close', function () {
       that.hide();
     });
 
     // 跨域则使用arale-messenger进行通信
-    var m = new _araleMessenger2.default('parent', 'arale-dialog');
+    var m = new _araleMessenger2['default']('parent', 'arale-dialog');
     this.iframe.one('load', function () {
       m.addTarget(that.iframe[0].contentWindow, 'iframe1');
       m.listen(function (data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arale-dialog",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Dialog 是通用对话框容器，提供显隐关闭、遮罩层、内嵌iframe、内容区域自定义以及模态对话框等功能。",
   "keywords": [
     "widget",
@@ -31,19 +31,21 @@
     "spm-handlebars": "~1.3.1"
   },
   "devDependencies": {
+    "arale-widget": "~1.2.1",
+    "atool-doc": "^0.4.3",
+    "atool-test": "~0.4.3",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
     "babel-istanbul": "^0.7.0",
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-class-properties": "^6.6.0",
+    "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
+    "babel-plugin-transform-es3-property-literals": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "jquery": "1.7.2",
-    "arale-widget": "~1.2.1",
-    "atool-doc": "^0.4.3",
-    "atool-test": "~0.4.3",
     "expect.js": "^0.3.1",
+    "jquery": "1.7.2",
     "nico": "*",
     "spm-sinon": "~1.6.0"
   },


### PR DESCRIPTION
增加两个 babel 插件，把export.default转为export["default"],  解决 ie 下 default 关键字的兼容问题。
